### PR TITLE
Remove backticks from Helm command

### DIFF
--- a/docs/getting-started/getting-started-darwin.md
+++ b/docs/getting-started/getting-started-darwin.md
@@ -210,9 +210,9 @@ $ brew install stackrox/rocksdb/rocksdb@6.15.5
 
 
 ## Install Helm
-    ```
-    $ brew install helm
-    ```
+```
+$ brew install helm
+```
 
 ### Verify
 


### PR DESCRIPTION
Noticed the original looked like this:

## Install Helm
    ```
    $ brew install helm
    ```

so changing it to look like this:

## Install Helm
```
$ brew install helm
```