### PR TITLE
Add note about setting UI_BASE_URL when connecting to remote central.

### DIFF
--- a/docs/knowledge-base/[FE] Use-remote-Central-for-local-front-end-dev.md
+++ b/docs/knowledge-base/[FE] Use-remote-Central-for-local-front-end-dev.md
@@ -52,7 +52,10 @@ that is already running, you can use one of the following, depending on
 whether it has a public IP. 
 
 -   If it has a public IP, export that in the `YARN_START_TARGET` env var and start 
-    the front-end by running `export YARN_START_TARGET=<external_IP>; yarn start`
+    the front-end by running `export YARN_START_TARGET=<external_IP>; yarn start`.
+    Note that you may also want to run `export UI_BASE_URL=<external_IP>;` for commands
+    that assume the backend will be available on localhost:8000 (such as `yarn cypress-open`).
+
 
 -   If it does not have a public IP or a demo URL, you can use steps 2
     and 4 from the section above, **Using Remote StackRox Deployment**.


### PR DESCRIPTION
This is something I ran into when running Cypress against a qa-demo cluster, using `export YARN_START_TARGET` instead of `yarn forward`. (K8s port forwarding has been incredibly flaky for me.)

Cypress would fail to generate the auth token with no other error because it was trying to connect to `https://localhost:8000`.

An alternative to this would be to change the default URL in some of the UI scripts to `https://localhost:3000`. However, I'm not sure if this would impact CI, and there are some graphql commands that also rely on this value.