### PR TITLE
GHA: set board to OSS triaging

### DIFF
--- a/.github/workflows/add-new-pr-to-oss-triaging.yml
+++ b/.github/workflows/add-new-pr-to-oss-triaging.yml
@@ -5,8 +5,7 @@ on:
 
 env:
   EXTERNAL_PR_LABEL: external-contributor
-  PROJECT_URL: https://github.com/orgs/stackrox/projects/3 # Test board for PR automation
-  # PROJECT_URL: https://github.com/orgs/stackrox/projects/2 # OSS Triaging board
+  PROJECT_URL: https://github.com/orgs/stackrox/projects/2 # OSS Triaging board
 
 jobs:
   check-pr-if-external:


### PR DESCRIPTION
Example of internal PR: https://github.com/stackrox/dev-docs/pull/18
Example of external PR - added to [board](https://github.com/orgs/stackrox/projects/3/views/1?layout=board): https://github.com/stackrox/dev-docs/pull/19